### PR TITLE
Apply 'final' keyword to generated gRPC clients

### DIFF
--- a/Plugin/Templates/client.swift
+++ b/Plugin/Templates/client.swift
@@ -22,7 +22,7 @@
 //-{% endif %}
 //-{% endfor %}
 /// Call methods of this class to make API calls.
-{{ access }} class {{ .|serviceclass:file,service }} {
+{{ access }} final class {{ .|serviceclass:file,service }} {
   public var channel: Channel
 
   /// This metadata will be sent with all requests.


### PR DESCRIPTION
This changeset proposes a fix for grpc/grpc-swift#103, wherein initializers cannot be made to be enforced in a generic manner without one of either:
- The `final` keyword being added to the generated client class
- The `required` keyword being added to enforced constructors

The approach taken here is simply to add `final` to generated gRPC client classes.